### PR TITLE
Fix generating wrong thumbnail URLs

### DIFF
--- a/includes/Repo/LocalWebPFile.php
+++ b/includes/Repo/LocalWebPFile.php
@@ -99,7 +99,7 @@ class LocalWebPFile extends LocalFile {
 			] );
 		}
 
-		$transformed = parent::transform( $params, $flags );
+		$transformed = parent::transform( $normalized, $flags );
 
 		if ( $transformed === false || !WebPTransformer::canTransform( $this ) ) {
 			wfDebugLog(
@@ -110,12 +110,14 @@ class LocalWebPFile extends LocalFile {
 			return $transformed;
 		}
 
-		$thumbName = $this->thumbName( $params );
+		$thumbName = $this->thumbName( $normalized );
 
-		$url = $this->getThumbUrl( $thumbName );
+		$url = $this->getThumbUrl( $normalized );
 		if ( MediaWikiServices::getInstance()->getMainConfig()->get( 'ThumbnailScriptPath' ) !== false ) {
 			$url = $transformed->getUrl();
 		}
+
+		$path = $this->getThumbPath( $this->thumbName( $normalized ) )
 
 		wfDebugLog(
 			'WebP',
@@ -123,11 +125,11 @@ class LocalWebPFile extends LocalFile {
 			'all',
 			[
 				'url' => $url,
-				'path' => $this->getThumbPath( $this->thumbName( $params ) ),
+				'path' => $path,
 			]
 		);
 
-		return new ThumbnailImage( $this, $url, $this->getThumbPath( $this->thumbName( $params ) ), [
+		return new ThumbnailImage( $this, $url, $path, [
 			'width' => $transformed->getWidth(),
 			'height' => $transformed->getHeight(),
 		] );


### PR DESCRIPTION
I've installed version from `develop` branch on MW 1.38.2. Images and thumbnails are converted properly, but thumbnails URLs were wrong:
```
[WebP] [LocalWebPFileRepo::getZoneUrl] Returning zone url "//media.crystalls.info/w/uploads/media/thumb/webp" for zone "webp-thumb"
[WebP] [LocalWebPFile::getThumbUrl] Returning thumb url "//media.crystalls.info/w/uploads/media/thumb/webp/A.chernykh.copper.sulfate.1.jpg/543px-A.chernykh.copper.sulfate.1.webp" for "A.chernykh.copper.sulfate.1.jpg"
[WebP] [LocalWebPFileRepo::getZonePath] Returning zone path "mwstore://local-backend/local-thumb/webp"
[WebP] [LocalWebPFile::getThumbPath] Returning thumb path "mwstore://local-backend/local-thumb/webp/A.chernykh.copper.sulfate.1.jpg/543px-A.chernykh.copper.sulfate.1.webp" for "A.chernykh.copper.sulfate.1.jpg"
File::transform: Doing stat for mwstore://local-backend/local-thumb/webp/A.chernykh.copper.sulfate.1.jpg/543px-A.chernykh.copper.sulfate.1.webp
[WebP] [LocalWebPFileRepo::fileExists] File "mwstore://local-backend/local-thumb/webp/A.chernykh.copper.sulfate.1.jpg/543px-A.chernykh.copper.sulfate.1.webp" exists: 1
TransformationalImageHandler::doTransform: creating 543x375 thumbnail at mwstore://local-backend/local-thumb/webp/A.chernykh.copper.sulfate.1.jpg/543px-A.chernykh.copper.sulfate.1.webp using scaler im
TransformationalImageHandler::doTransform: Transforming later per flags.



[WebP] [LocalWebPFileRepo::getZoneUrl] Returning zone url "//media.crystalls.info/w/uploads/media/thumb/webp" for zone "webp-thumb"
[WebP] [LocalWebPFile::getThumbUrl] Returning thumb url "//media.crystalls.info/w/uploads/media/thumb/webp/A.chernykh.copper.sulfate.1.jpg/3900px-A.chernykh.copper.sulfate.1.webp" for "A.chernykh.copper.sulfate.1.jpg"
[WebP] [LocalWebPFileRepo::getZonePath] Returning zone path "mwstore://local-backend/local-thumb/webp"
[WebP] [LocalWebPFile::getThumbPath] Returning thumb path "mwstore://local-backend/local-thumb/webp/A.chernykh.copper.sulfate.1.jpg/3900px-A.chernykh.copper.sulfate.1.webp" for "A.chernykh.copper.sulfate.1.jpg"
[WebP] [LocalWebPFile::transform] Returning webp transform for "A.chernykh.copper.sulfate.1.jpg"
[WebP] [LocalWebPFileRepo::getZonePath] Returning zone path "mwstore://local-backend/local-thumb/webp"
[WebP] [LocalWebPFile::getThumbPath] Returning thumb path "mwstore://local-backend/local-thumb/webp/A.chernykh.copper.sulfate.1.jpg/3900px-A.chernykh.copper.sulfate.1.webp" for "A.chernykh.copper.sulfate.1.jpg"
```

File is called `543px-A.chernykh.copper.sulfate.1.webp`, but thumbnail URL is `3900px-A.chernykh.copper.sulfate.1.webp`.

This is because my laptop screen has width about `3900px`, and it looks like instead of `$normalized` params a raw size is used. Now it is fixed.